### PR TITLE
Fix onoscli sendline expect

### DIFF
--- a/TestON/drivers/common/cli/onosclidriver.py
+++ b/TestON/drivers/common/cli/onosclidriver.py
@@ -261,7 +261,6 @@ class OnosCliDriver( CLI ):
                                   + cmdStr + "'\"" )
             self.handle.expect( "onos>" )
             self.handle.sendline( cmdStr )
-            self.handle.expect( cmdStr )
             self.handle.expect( "onos>" )
 
             handle = self.handle.before


### PR DESCRIPTION
    * long commands tend to have extra control characters in the middle
      that will mess with our expect call